### PR TITLE
187 bug withdraw and add commands follows different behaviour when no amount is provided 1

### DIFF
--- a/src/main/java/seedu/duke/constants/ErrorMessage.java
+++ b/src/main/java/seedu/duke/constants/ErrorMessage.java
@@ -4,7 +4,9 @@ package seedu.duke.constants;
  * A public interface that is used to contain all the error messages throughout the application.
  */
 public interface ErrorMessage {
-    String INVALID_ADD_COMMAND = "Please check that you have correctly provided the currency and amount";
+    String INVALID_ADD_COMMAND = "This is an invalid add command format. \n" +
+        "Please check that you have correctly provided the currency and amount according this format:\n" +
+        "\t add CURRENCY AMOUNT [DESCRIPTION]";
     String INVALID_TOO_SMALL_AMOUNT_TO_ADD_OR_WITHDRAW = "Please provide a value greater than or equal to 0.01";
     String INVALID_COMMAND_TOO_PRECISE_AMOUNT = "Please provide an amount that has a precision of not more than 2 dp";
     String INVALID_WITHDRAW_COMMAND = "This is an invalid withdraw command format. \n" +

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -21,7 +21,7 @@ public class Ui {
     public String getUserInput() {
         // The replaceAll method is used to replace all sets of consecutive spaces with a single space.
         // This will prevent people from breaking our app with multiple spaces.
-        return in.nextLine().replaceAll("\\s+", " ");
+        return in.nextLine().replaceAll("\\s+", " ").trim();
     }
 
     /**


### PR DESCRIPTION
# Description

The Add and Withdraw commands have different error messages even though their functionality are similar (to update the balance). I have updated the error message for the Add command so that it is similar to the Withdraw command. Furthermore, I noticed that having an extra space will result in different error messages so I used the trim method in the getInput method.

## Type of Change

- [X] Possible breaking change (Change in feature that may cause existing features to not work correctly, e.g. change in
  schema)
- [X] Non breaking change (Bug fix, New feature)

## What type of PR is this?

- [X] bug fix

## Which issue(s) this PR fixes, if:

Fixes #187 

## Special notes for your reviewer:

#### Additional documentation e.g., usage docs, testing docs etc.:

## Checklist

- [X] Changes have been tested
- [X] All automated tests pass
- [X] Relevant Tags and Milestones have been added